### PR TITLE
Get dynamic kafka records

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
          support ANSI color codes by default. -->
     <withJansi>true</withJansi>
     <encoder>
-      <pattern>[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n</pattern>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n</pattern>
     </encoder>
   </appender>
   <root level="INFO">

--- a/src/main/scala/com/condukt/api/ApiRoutes.scala
+++ b/src/main/scala/com/condukt/api/ApiRoutes.scala
@@ -15,7 +15,7 @@ object ApiRoutes {
     import dsl._
     object Count extends OptionalQueryParamDecoderMatcher[Int]("count")
 
-    def getPeople(topicName: String, offset: Int, count: Int): F[Response[F]] = {
+    def getPeople(topicName: String, offset: Long, count: Int): F[Response[F]] = {
       println(s"[offset=$offset, count=$count]")
       logger.info(s"[offset=$offset, count=$count]")
       for {
@@ -24,8 +24,9 @@ object ApiRoutes {
       } yield resp
     }
 
+    //havent done any bad request validation, returns 404 when string is passed for either or both path and query param
     HttpRoutes.of[F] {
-      case GET -> Root / "topic" / topic_name / IntVar(offset) :? Count(count) =>
+      case GET -> Root / "topic" / topic_name / LongVar(offset) :? Count(count) =>
         count match {
           case Some(count) =>
             getPeople(topic_name, offset, count)

--- a/src/main/scala/com/condukt/api/AppServer.scala
+++ b/src/main/scala/com/condukt/api/AppServer.scala
@@ -2,7 +2,7 @@ package com.condukt.api
 
 import cats.effect.{Async, Resource}
 import com.comcast.ip4s._
-import com.condukt.api.producer.{DefaultRandomPeopleService, PeopleFileReader, RandomPeopleProducerFactory}
+import com.condukt.api.producer.{DefaultPeoplePopulatorService, PeopleFileReader, RandomPeopleProducerFactory}
 import com.condukt.api.producer.model.Person
 import fs2.io.net.Network
 import org.apache.kafka.clients.producer.KafkaProducer
@@ -27,7 +27,7 @@ object AppServer {
       peopleProducer: KafkaProducer[String, Person] <- RandomPeopleProducerFactory(kafkaBootstrapServers)
       people <- Resource.eval(PeopleFileReader[F](filePath))
       _ = logger.info(s"read file, there are ${people.size} records")
-      _ = new DefaultRandomPeopleService[F](peopleProducer).populateTopic(people, topic)
+      _ = new DefaultPeoplePopulatorService[F](peopleProducer).populateTopic(people, topic)
       _ = logger.info(s"records sent to topic: ${topic}")
       _ <- EmberClientBuilder.default[F].build
       peopleQueryService = PeopleQueryService.default[F]

--- a/src/main/scala/com/condukt/api/AppServer.scala
+++ b/src/main/scala/com/condukt/api/AppServer.scala
@@ -5,7 +5,6 @@ import com.comcast.ip4s._
 import com.condukt.api.consumer.{KafkaPeopleRepository, PersonConsumer}
 import com.condukt.api.producer.{DefaultPeoplePopulatorService, PeopleFileReader, PersonProducer}
 import fs2.io.net.Network
-import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.implicits._
 import org.http4s.server.middleware.Logger
@@ -15,7 +14,7 @@ object AppServer {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  //probably environment variables
+  //probably should be environment variables that is passed into the app
   val kafkaBootstrapServers = "localhost:9092"
   val filePath = "random-people-data.json"
   val topic = "people"
@@ -25,13 +24,12 @@ object AppServer {
   def run[F[_]: Async: Network]: F[Nothing] = {
 
     for {
-      personProducer <- PersonProducer(kafkaBootstrapServers)
       personConsumer <- PersonConsumer(kafkaBootstrapServers, consumerGroupId, pollMaxRecords)
       people <- Resource.eval(PeopleFileReader[F](filePath))
       _ = logger.info(s"read file, there are ${people.size} records")
-      _ = new DefaultPeoplePopulatorService[F](personProducer).populateTopic(people, topic)
-      _ = logger.info(s"records sent to topic: ${topic}")
-      _ <- EmberClientBuilder.default[F].build
+      _ <- Resource.eval(PersonProducer(kafkaBootstrapServers).use { producer =>
+                          new DefaultPeoplePopulatorService[F](producer).populateTopic(people, topic)
+                        })
       repository = new KafkaPeopleRepository(personConsumer)
       peopleQueryService = PeopleQueryService.default[F](repository)
       // Combine Service Routes into an HttpApp.

--- a/src/main/scala/com/condukt/api/PeopleQueryService.scala
+++ b/src/main/scala/com/condukt/api/PeopleQueryService.scala
@@ -1,28 +1,16 @@
 package com.condukt.api
 
-import cats.effect.Sync
-import com.condukt.api.producer.model.{Address, Person}
-
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
+import com.condukt.api.consumer.PeopleRepository
+import com.condukt.api.producer.model.Person
 
 trait PeopleQueryService[F[_]]{
-  def retrievePeople(topic: String, offset: Int, count: Int): F[List[Person]]
+  def retrievePeople(topic: String, offset: Long, count: Int): F[Seq[Person]]
 }
 
 object PeopleQueryService {
 
-  private val mockPerson: Person = Person(_id = "368YCC2THQH1HEAQ", name = "Kiana Yoo",
-    dob = LocalDate.parse("2021-05-31", DateTimeFormatter.ISO_LOCAL_DATE),
-    address = Address("2745 Shaftsbury Circle", "Slough", "LS67 1ID"),
-    telephone = "+39-3380-033-155", pets = List("Sadie", "Rosie"),
-    score = 3.7, email = "palma14@hotmail.com", url = "http://earth.com",
-    description = "strips rt administrators composer ...", verified = true, salary = 31900)
-
-  val mockPeople = List(mockPerson, mockPerson.copy(_id = "111YCC2THQH1QAEH"))
-
-  def default[F[_]: Sync]: PeopleQueryService[F] = new PeopleQueryService[F] {
-    def retrievePeople(topic: String, offset: Int, count: Int): F[List[Person]] =
-      Sync[F].delay(mockPeople)
+  def default[F[_]](peopleRepository: PeopleRepository[F]): PeopleQueryService[F] = new PeopleQueryService[F] {
+    def retrievePeople(topic: String, offset: Long, count: Int): F[Seq[Person]] =
+      peopleRepository.getPeople(topic, offset, count)
   }
 }

--- a/src/main/scala/com/condukt/api/PeopleRepository.scala
+++ b/src/main/scala/com/condukt/api/PeopleRepository.scala
@@ -2,8 +2,7 @@ package com.condukt.api
 
 import cats.effect.Sync
 import com.condukt.api.producer.model.Person
-import org.apache.kafka.clients.admin.{AdminClient, TopicDescription}
-import org.apache.kafka.common.{KafkaFuture, TopicPartition}
+import org.apache.kafka.common.{PartitionInfo, TopicPartition}
 import org.apache.kafka.clients.consumer.KafkaConsumer
 
 import java.time.Duration
@@ -15,58 +14,51 @@ trait PeopleRepository[F[_]] {
   def getPeople(topicName: String, offset: Long, count: Int): F[Seq[Person]]
 }
 
-class KafkaPeopleRepository[F[_]: Sync](adminClient: AdminClient, kafkaConsumer: KafkaConsumer[String, Person]) extends PeopleRepository[F] {
-
+class KafkaPeopleRepository[F[_]: Sync](kafkaConsumer: KafkaConsumer[String, Person]) extends PeopleRepository[F] {
 
   override def getPeople(topicName: String, offset: Long, count: Int): F[Seq[Person]] =
-    Sync[F].blocking {
-      val topicDescription: KafkaFuture[TopicDescription] =
-        adminClient
-          .describeTopics(List(topicName).asJava)
-          .topicNameValues()
-          .get(topicName)
-      getPeopleFromTopic(topicName, offset, count, topicDescription.get())
+    Sync[F].delay {
+      val partitions = kafkaConsumer.partitionsFor(topicName).asScala.toList
+      getPeopleFromTopic(partitions, topicName, offset, count)
     }
 
+  private def getPeopleFromTopic(partitions: Seq[PartitionInfo], topicName: String, offset: Long, count: Int): Seq[Person] = {
+    val allTopicPartitions = partitions
+      .map { partitionInfo =>
+        new TopicPartition(topicName, partitionInfo.partition())
+      }.toList
 
-  private def getPeopleFromTopic(topicName: String, offset: Long, count: Int, topicDescription: TopicDescription): Seq[Person] = {
-    topicDescription
-      .partitions()
-      .asScala
-      .flatMap { partitionInfo =>
-        val partition = new TopicPartition(topicName, partitionInfo.partition())
-        val maybePeople =
-          Try(kafkaConsumer.assign(List(partition).asJava))
-            .flatMap { _ =>
-              Try(kafkaConsumer.seek(partition, offset))
-            }
-        maybePeople match {
-          case Success(_) =>
-            getRecords(List.empty, count)
-              .take(count)
-          case Failure(exception) =>
-            println(s"${exception.getMessage}")
-            Seq.empty
-        }
-    }.toList
+     Try(kafkaConsumer.assign(allTopicPartitions.asJava)) match {
+       case Success(_) =>
+         allTopicPartitions
+           .foreach { partition =>
+             kafkaConsumer.seek(partition, offset) //starts the offset from the same position for each partition
+           }
+         handleRetrieval(Seq.empty, offset, count) //then retrieve from offset start
+       case Failure(_) =>
+         Seq.empty
+     }
+
   }
 
   @tailrec
-  private def getRecords(people: List[Person], count: Int): List[Person] = {
-    if(people.size >= count) {
-      people
+  private def handleRetrieval(recordsSoFar: Seq[Person], offset: Long, count: Int): Seq[Person] = {
+    val currentRecordsPulled =
+      kafkaConsumer
+        .poll(Duration.ofMillis(500))
+        .asScala
+        .tapEach(record => println(s"id=${record.value()._id},offset=${record.offset()}"))
+        .filter(record => record.offset() >= offset)
+        .map(_.value())
+        .toSeq
+    val total = (currentRecordsPulled ++ recordsSoFar).take(count)
+
+    println(s"${total.map(_._id)}")
+
+    if(total.size == count || currentRecordsPulled.isEmpty) {
+      total
     } else {
-      val morePeople =
-        kafkaConsumer
-          .poll(Duration.ofMillis(500))
-          .asScala
-          .map(_.value())
-          .toList
-      if(morePeople.isEmpty) {
-        people
-      } else {
-        getRecords(people ++ morePeople, count)
-      }
+      handleRetrieval(total, offset, count)
     }
   }
 }

--- a/src/main/scala/com/condukt/api/consumer/PersonConsumer.scala
+++ b/src/main/scala/com/condukt/api/consumer/PersonConsumer.scala
@@ -1,0 +1,28 @@
+package com.condukt.api.consumer
+
+import cats.effect.{Resource, Sync}
+import com.condukt.api.producer.model.{Person, PersonDeserializer}
+import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
+import org.apache.kafka.common.serialization.StringDeserializer
+
+import java.util.Properties
+
+object PersonConsumer {
+
+  def apply[F[_]: Sync](bootstrapServers: String, groupId: String, maxPollRecords: Int): Resource[F, KafkaConsumer[String, Person]] =
+    Resource.make {
+      Sync[F].delay {
+        val props = new Properties()
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId)
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[PersonDeserializer].getName)
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords)
+
+        new KafkaConsumer[String, Person](props)
+      }
+    }(consumer => Sync[F].delay(consumer.close()))
+
+}

--- a/src/main/scala/com/condukt/api/producer/PeoplePopulatorService.scala
+++ b/src/main/scala/com/condukt/api/producer/PeoplePopulatorService.scala
@@ -8,11 +8,11 @@ import com.condukt.api.producer.model.{Person, PersonSerializer}
 import org.apache.kafka.common.serialization.StringSerializer
 import cats.syntax.all._
 
-trait RandomPeopleService[F[_]] {
+trait PeoplePopulatorService[F[_]] {
   def populateTopic(topic: String, filePath: String): F[Unit]
 }
 
-class DefaultRandomPeopleService[F[_]: Sync](producer: KafkaProducer[String, Person]) {
+class DefaultPeoplePopulatorService[F[_]: Sync](producer: KafkaProducer[String, Person]) {
 
   def populateTopic(people: List[Person], topic: String): F[Unit] = {
     val sendActions: List[F[Unit]] = people.map { person =>

--- a/src/main/scala/com/condukt/api/producer/PeoplePopulatorService.scala
+++ b/src/main/scala/com/condukt/api/producer/PeoplePopulatorService.scala
@@ -31,7 +31,7 @@ class DefaultPeoplePopulatorService[F[_]: Sync](producer: KafkaProducer[String, 
 
 }
 
-object RandomPeopleProducerFactory {
+object PersonProducer {
   def apply[F[_]: Sync](broker: String): Resource[F, KafkaProducer[String, Person]] = {
     val props = new Properties()
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, broker)

--- a/src/main/scala/com/condukt/api/producer/model/Person.scala
+++ b/src/main/scala/com/condukt/api/producer/model/Person.scala
@@ -22,6 +22,6 @@ final case class Person(
                          salary: Int
                  )
 object Person {
-  implicit def greetingEntityEncoder[F[_]]: EntityEncoder[F, List[Person]] =
-    jsonEncoderOf[F, List[Person]]
+  implicit def greetingEntityEncoder[F[_]]: EntityEncoder[F, Seq[Person]] =
+    jsonEncoderOf[F, Seq[Person]]
 }

--- a/src/test/scala/com/condukt/api/KafkaPeopleRepositorySpec.scala
+++ b/src/test/scala/com/condukt/api/KafkaPeopleRepositorySpec.scala
@@ -19,12 +19,9 @@ import java.util.Properties
 
 class KafkaPeopleRepositorySpec extends AnyWordSpec with Matchers {
 
-  val logger: Logger = LoggerFactory.getLogger(this.getClass)
-
   "KafkaPeopleRepository.getPeople" should {
     "return people" when {
       "they exist as records in the topic" in {
-        logger.info("Hello there kenneth")
         val secondPerson = PersonSpec.defaultPerson.copy("2222222222222222")
         val thirdPerson = PersonSpec.defaultPerson.copy("333333333333333")
         val people = List(PersonSpec.defaultPerson, secondPerson, thirdPerson)
@@ -97,7 +94,7 @@ object KafkaPeopleRepositorySpec {
       props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[PersonDeserializer].getName)
       props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
       props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-      props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 10)
+      props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)
 
       new KafkaConsumer[String, Person](props)
     }

--- a/src/test/scala/com/condukt/api/KafkaPeopleRepositorySpec.scala
+++ b/src/test/scala/com/condukt/api/KafkaPeopleRepositorySpec.scala
@@ -76,6 +76,17 @@ class KafkaPeopleRepositorySpec extends AnyWordSpec with Matchers {
         }
       }
 
+      "topic does not exist" in {
+        val expected = List.empty
+        val topicNameToBeCreated = s"people-${UUID.randomUUID()}"
+        val incorrectTopic = "incorrectTopic"
+        withKafka(topicNameToBeCreated, expected) { consumer =>
+          val repository = new KafkaPeopleRepository[IO](consumer)
+          val result = repository.getPeople(incorrectTopic, 0, 1).unsafeRunSync()
+          result.map(_._id) mustBe List.empty
+        }
+      }
+
       "offset is more than records in the topic" in {
         val firstPerson = PersonSpec.defaultPerson.copy(_id = "1")
         val secondPerson = PersonSpec.defaultPerson.copy(_id = "2")

--- a/src/test/scala/com/condukt/api/KafkaPeopleRepositorySpec.scala
+++ b/src/test/scala/com/condukt/api/KafkaPeopleRepositorySpec.scala
@@ -6,7 +6,7 @@ import com.condukt.api.KafkaPeopleRepositorySpec._
 import com.condukt.api.producer.model.{Person, PersonDeserializer, PersonSerializer, PersonSpec}
 import com.dimafeng.testcontainers.KafkaContainer
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
-import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.scalatest.Assertion
@@ -91,12 +91,13 @@ object KafkaPeopleRepositorySpec {
   private def testConsumer(bootstrapServers: String): Resource[IO, KafkaConsumer[String, Person]] = Resource.make {
     IO {
       val props = new Properties()
-      props.put("bootstrap.servers", bootstrapServers)
-      props.put("group.id", "test-repository-consumer-group")
-      props.put("key.deserializer", classOf[StringDeserializer].getName)
-      props.put("value.deserializer", classOf[PersonDeserializer].getName)
-      props.put("enable.auto.commit", "false")
-      props.put("auto.offset.reset", "earliest")
+      props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+      props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-repository-consumer-group")
+      props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
+      props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[PersonDeserializer].getName)
+      props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+      props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 10)
 
       new KafkaConsumer[String, Person](props)
     }

--- a/src/test/scala/com/condukt/api/consumer/KafkaPeopleRepositorySpec.scala
+++ b/src/test/scala/com/condukt/api/consumer/KafkaPeopleRepositorySpec.scala
@@ -1,8 +1,8 @@
-package com.condukt.api
+package com.condukt.api.consumer
 
-import cats.effect.{IO, Resource}
 import cats.effect.unsafe.implicits.global
-import com.condukt.api.KafkaPeopleRepositorySpec._
+import cats.effect.{IO, Resource}
+import com.condukt.api.consumer.KafkaPeopleRepositorySpec.withKafka
 import com.condukt.api.producer.model.{Person, PersonDeserializer, PersonSerializer, PersonSpec}
 import com.dimafeng.testcontainers.KafkaContainer
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}

--- a/src/test/scala/com/condukt/api/producer/PeoplePopulatorServiceSpec.scala
+++ b/src/test/scala/com/condukt/api/producer/PeoplePopulatorServiceSpec.scala
@@ -21,12 +21,12 @@ import java.util.{Properties, UUID}
 import scala.jdk.CollectionConverters._
 
 //would reduce the time taken for tests, stopping container only after all the tests are run
-class RandomPeopleServiceSpec extends AnyWordSpec with Matchers {
+class PeoplePopulatorServiceSpec extends AnyWordSpec with Matchers {
 
   val container: KafkaContainer = KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.7.0"))
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  "RandomPeopleService.populateTopic" should {
+  "PeoplePopulatorService.populateTopic" should {
     "populate with list of people" when {
       "the list is provided" in {
         val topicName = s"people-${UUID.randomUUID()}"
@@ -34,7 +34,7 @@ class RandomPeopleServiceSpec extends AnyWordSpec with Matchers {
         val records = List(defaultPerson, secondPerson)
 
         withKafka(container, topicName) { producer =>
-          new DefaultRandomPeopleService[IO](producer).populateTopic(records, topicName).unsafeRunSync()
+          new DefaultPeoplePopulatorService[IO](producer).populateTopic(records, topicName).unsafeRunSync()
           val noOfMessages = readMessages(container.bootstrapServers, topicName).unsafeRunSync()
 
           noOfMessages must contain theSameElementsAs records
@@ -48,7 +48,7 @@ class RandomPeopleServiceSpec extends AnyWordSpec with Matchers {
         val emptyRecords = List.empty
 
         withKafka(container, topicName) { producer =>
-          new DefaultRandomPeopleService[IO](producer).populateTopic(emptyRecords, topicName).unsafeRunSync()
+          new DefaultPeoplePopulatorService[IO](producer).populateTopic(emptyRecords, topicName).unsafeRunSync()
           val noOfMessages = readMessages(container.bootstrapServers, topicName).unsafeRunSync().size
           noOfMessages mustBe 0
         }

--- a/src/test/scala/com/condukt/api/producer/PeoplePopulatorServiceSpec.scala
+++ b/src/test/scala/com/condukt/api/producer/PeoplePopulatorServiceSpec.scala
@@ -31,13 +31,13 @@ class PeoplePopulatorServiceSpec extends AnyWordSpec with Matchers {
       "the list is provided" in {
         val topicName = s"people-${UUID.randomUUID()}"
         val secondPerson = defaultPerson.copy(_id = "168YCC2THQH1HEAB")
-        val records = List(defaultPerson, secondPerson)
+        val expected = List(defaultPerson, secondPerson)
 
         withKafka(container, topicName) { producer =>
-          new DefaultPeoplePopulatorService[IO](producer).populateTopic(records, topicName).unsafeRunSync()
-          val noOfMessages = readMessages(container.bootstrapServers, topicName).unsafeRunSync()
+          new DefaultPeoplePopulatorService[IO](producer).populateTopic(expected, topicName).unsafeRunSync()
+          val result = readMessages(container.bootstrapServers, topicName).unsafeRunSync()
 
-          noOfMessages must contain theSameElementsAs records
+          result must contain theSameElementsAs expected
         }
       }
     }
@@ -49,8 +49,8 @@ class PeoplePopulatorServiceSpec extends AnyWordSpec with Matchers {
 
         withKafka(container, topicName) { producer =>
           new DefaultPeoplePopulatorService[IO](producer).populateTopic(emptyRecords, topicName).unsafeRunSync()
-          val noOfMessages = readMessages(container.bootstrapServers, topicName).unsafeRunSync().size
-          noOfMessages mustBe 0
+          val result = readMessages(container.bootstrapServers, topicName).unsafeRunSync()
+          result mustBe emptyRecords
         }
       }
     }

--- a/src/test/scala/com/condukt/api/producer/PeoplePopulatorServiceSpec.scala
+++ b/src/test/scala/com/condukt/api/producer/PeoplePopulatorServiceSpec.scala
@@ -85,7 +85,7 @@ object RandomPeopleServiceSpec {
           .use { client =>
             for {
               _                 <- createTopic(client, topic)
-              producerResource  = RandomPeopleProducerFactory[IO](container.bootstrapServers)
+              producerResource  = PersonProducer[IO](container.bootstrapServers)
               result            <- producerResource.use(producer => IO(testFn(producer)))
               _                 <- IO(container.stop())
             } yield result

--- a/src/test/scala/com/condukt/api/producer/model/PersonSpec.scala
+++ b/src/test/scala/com/condukt/api/producer/model/PersonSpec.scala
@@ -33,6 +33,7 @@ class PersonSpec extends AnyWordSpec with Matchers {
 }
 
 object PersonSpec {
+  // below is being used in most tests, maybe having a seperate test class that holds the values and also the json values might be useful to indicate defaultPerson is commonly used in testing
   val defaultPerson: Person =
     Person(_id = "368YCC2THQH1HEAQ", name = "Kiana Yoo",
           dob = LocalDate.parse("2021-05-31", DateTimeFormatter.ISO_LOCAL_DATE),

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Stop and remove the existing container if it exists
+# shellcheck disable=SC2046
 if [ $(docker ps -aq -f name=kafka-people) ]; then
     docker stop kafka-people
     docker rm kafka-people
@@ -7,9 +8,13 @@ fi
 if [[ -f kafka.log ]]; then
     rm kafka.log
 fi
+if [[ -f kafka_offsets.log ]]; then
+    rm kafka_offsets.log
+fi
 docker run --name kafka-people -p 9092:9092 apache/kafka:3.7.0 > kafka.log 2>&1 &
 sleep 5
 docker exec -it kafka-people /opt/kafka/bin/kafka-topics.sh --create --topic people --bootstrap-server localhost:9092 --partitions 3 --replication-factor 1 --config cleanup.policy=delete
 docker exec -it kafka-people /opt/kafka/bin/kafka-topics.sh --list --bootstrap-server localhost:9092
 sleep 5
 sbt run
+docker exec -it kafka-people /opt/kafka/bin/kafka-get-offsets.sh --broker-list localhost:9092 --topic people > kafka_offsets.log 2>&1


### PR DESCRIPTION
- can get person records via the REST Get endpoint now by offset and count
- offset is set for all partitions as the starting point
- count is used to limit the number of records returned via recursion